### PR TITLE
Add mouseover actions for top/currentOp

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -11,7 +11,9 @@ const Actions = Reflux.createActions([
   'dbError',
   'showOperationDetails',
   'hideOperationDetails',
-  'restart'
+  'restart',
+  'mouseOut',
+  'mouseOver'
 ]);
 
 module.exports = Actions;

--- a/src/components/d3component.jsx
+++ b/src/components/d3component.jsx
@@ -1,8 +1,7 @@
 const React = require('react');
 const ReactDOM = require('react-dom');
 const d3 = require('d3');
-const TopStore = require('../stores/top-store');
-const CurrentOpStore = require('../stores/current-op-store');
+const Actions = require('../actions');
 
 const LINE_COLORS = ['#45BAAB', '#23B1FF', '#6F72FF', '#A33A35', '#FFA900', '#C7E82F'];
 
@@ -85,10 +84,8 @@ class D3Component extends React.Component {
       .defined((d, i) => !data.skip[i])
       .color(d3.scale.ordinal().range(LINE_COLORS))
       .strokeWidth(2)
-      .on('mouseover', TopStore.mouseOver)
-      .on('mouseover', CurrentOpStore.mouseOver)
-      .on('mouseout', TopStore.mouseOut)
-      .on('mouseout', CurrentOpStore.mouseOut);
+      .on('mouseover', Actions.mouseOver)
+      .on('mouseout', Actions.mouseOut);
 
     d3.select(el)
       .datum(this.props.data)

--- a/src/stores/current-op-store.js
+++ b/src/stores/current-op-store.js
@@ -22,6 +22,8 @@ const CurrentOpStore = Reflux.createStore({
     this.listenTo(Actions.pollCurrentOp, this.currentOp);
     this.listenTo(Actions.pause, this.pause);
     this.listenTo(Actions.restart, this.restart);
+    this.listenTo(Actions.mouseOver, this.mouseOver);
+    this.listenTo(Actions.mouseOut, this.mouseOut);
   },
 
   restart: function() {

--- a/src/stores/top-store.js
+++ b/src/stores/top-store.js
@@ -22,6 +22,8 @@ const TopStore = Reflux.createStore({
     this.listenTo(Actions.pollTop, this.top_delta);
     this.listenTo(Actions.pause, this.pause);
     this.listenTo(Actions.restart, this.restart);
+    this.listenTo(Actions.mouseOver, this.mouseOver);
+    this.listenTo(Actions.mouseOut, this.mouseOut);
   },
 
   restart: function() {


### PR DESCRIPTION
Instead of calling mouseover/mouseout directly on CurrentOpStore and TopStore, use actions so the lists will update with the overlays.