### PR TITLE
Fix style on detailview.

### DIFF
--- a/styles/rtss-lists.less
+++ b/styles/rtss-lists.less
@@ -206,7 +206,6 @@
 /* DETAIL VIEW */
 .rt-details__body {
   display: block;
-  flex-direction: column;
   position: relative;
   width: 400px;
   background-color: #484D51;


### PR DESCRIPTION
Before looked like:

![screen shot 2017-03-27 at 1 50 43 pm](https://cloud.githubusercontent.com/assets/1045019/24355000/80d11422-12f4-11e7-82d9-b9822f1c7c15.png)

Now looks like:

![screen shot 2017-03-27 at 1 51 16 pm 1](https://cloud.githubusercontent.com/assets/1045019/24355010/865d4a00-12f4-11e7-87e7-6fe294f615dc.png)

I don't know very much about CSS, I know that this fixes it but maybe there's a better solution?