### PR TITLE
CLOUDP-26145: RTPP2 - UI - Enable Scrubbing 

### DIFF
--- a/src/d3/real-time-mouse-overlay.js
+++ b/src/d3/real-time-mouse-overlay.js
@@ -73,8 +73,7 @@ function realTimeMouseOverlay() {
             clearInterval(updateMousePosition);
             eventDispatcher.mouseout(basePosition);
           });
-      }
-      else{
+      } else {
         mouseTarget
           .on('mouseover', null)
           .on('mousemove', null)

--- a/src/d3/real-time-mouse-overlay.js
+++ b/src/d3/real-time-mouse-overlay.js
@@ -54,7 +54,7 @@ function realTimeMouseOverlay() {
         .attr('height', height - (bubbleWidth / 2))
         .attr('width', width - bubbleWidth);
 
-      const mouseTargetEnter = mouseTarget.enter()
+      mouseTarget.enter()
         .append('rect')
         .attr('class', `${prefix}-mouse-target`)
         .attr('fill', 'none')
@@ -63,7 +63,7 @@ function realTimeMouseOverlay() {
         .style('pointer-events', 'visible');
 
       if (enableMouse) {
-        mouseTargetEnter
+        mouseTarget
           .on('mouseover', function() {
             const xPosition = d3.mouse(this)[0];
             eventDispatcher.mouseover(xPosition);
@@ -73,6 +73,12 @@ function realTimeMouseOverlay() {
             clearInterval(updateMousePosition);
             eventDispatcher.mouseout(basePosition);
           });
+      }
+      else{
+        mouseTarget
+          .on('mouseover', null)
+          .on('mousemove', null)
+          .on('mouseout', null);
       }
 
       if (overlayGroup.attr('transform') === `translate(${basePosition})`) {


### PR DESCRIPTION
JIRA Link: https://jira.mongodb.org/browse/CLOUDP-26145

In the process to enable mouse scrubbing on graphs (in our case, the Real Time Performance Profiling graphs), adjustments to d3 were necessary in updating the data received when the mouse is enabled vs. when it is not. When the mouse is enabled, the data updating the position of the mouse overlay can be properly communicated now since it has been appended to the target. The else statement added allows the dispatcher to communicate correct behavior when the mouse is not enabled. 