### PR TITLE
fix: prevent mouse cursor jumping COMPASS-4432

### DIFF
--- a/src/d3/real-time-mouse-overlay.js
+++ b/src/d3/real-time-mouse-overlay.js
@@ -54,7 +54,7 @@ function realTimeMouseOverlay() {
         .attr('height', height - (bubbleWidth / 2))
         .attr('width', width - bubbleWidth);
 
-      mouseTarget.enter()
+      const mouseTargetEnter = mouseTarget.enter()
         .append('rect')
         .attr('class', `${prefix}-mouse-target`)
         .attr('fill', 'none')
@@ -63,7 +63,7 @@ function realTimeMouseOverlay() {
         .style('pointer-events', 'visible');
 
       if (enableMouse) {
-        mouseTarget
+        mouseTargetEnter
           .on('mouseover', function() {
             const xPosition = d3.mouse(this)[0];
             eventDispatcher.mouseover(xPosition);
@@ -74,7 +74,7 @@ function realTimeMouseOverlay() {
             eventDispatcher.mouseout(basePosition);
           });
       } else {
-        mouseTarget
+        mouseTargetEnter
           .on('mouseover', null)
           .on('mousemove', null)
           .on('mouseout', null);


### PR DESCRIPTION
COMPASS-4432

Quick fix so that it only registers mouse events that occur inside the mouse target area.

Here's what it looks like now:

https://user-images.githubusercontent.com/1791149/111316294-0c36dc80-865b-11eb-988e-b20d886e8389.mp4

